### PR TITLE
refactor: remove custom commitlint configuration

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,9 +1,0 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-  /*
-   * Any rules defined here will override rules from @commitlint/config-conventional
-   */
-  rules: {
-    'body-max-line-length': [2, 'always', 200],
-  },
-};


### PR DESCRIPTION
Eliminate custom rules from commitlint configuration file to 
simplify the setup. The previous custom rule for body line 
length is removed, reverting to the default behavior, and 
streamlining the configuration for easier maintenance.